### PR TITLE
Revert "Update `ocaml_version` for coq:dev CI to run. Closes #23"

### DIFF
--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       matrix:
         coq_version:
+          - '8.12'
           - '8.13'
           - '8.14'
           - '8.15'
           - 'dev'
-        ocaml_version:
-          - '4.12-flambda'
+        ocaml_version: ['4.07-flambda']
       fail-fast: false # don't stop jobs if one fails
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
CI is being uncooperative. Will try to fix and re-merge.